### PR TITLE
Fix/package versioning june 2020

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update -y \
   && apt-get autoremove -y \
   && apt-get install -y \
-  ca-certificates=20190110 \
+  ca-certificates=20200601~deb10u1 \
   libpng-dev=1.6.36-6 \
   libjpeg62-turbo-dev=1:1.5.2-2+b1 \
   libwebp-dev=0.6.1-2 \
@@ -24,7 +24,7 @@ RUN apt-get update -y \
   vim=2:8.1.0875-5 \
   procps=2:3.3.15-2 \
   acl=2.2.53-4 \
-  git=1:2.20.1-2+deb10u1 \
+  git=1:2.20.1-2+deb10u3 \
   zip=3.0-11+b1 \
   sudo=1.8.27-1+deb10u2 \
   --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@
 This project provides a base-build container for Laravel projects by pulling in required dependencies and reducing build time for projects via CI.
 
 This specific repo builds nightly using the base image `php:7.2-fpm-buster` to provide additional updates and changes from the base.
+
+## Local Testing
+
+To quickly test the Dockerfile for builds, run the following command from the root of this repository on a system with Docker installed:
+
+```bash
+docker build --no-cache --compress -t troyfontaine/php72-laravel:test .
+```
+
+If you want to diagnose a version pinning issue for a package, launch the base container and try manually installing the package version in question:
+
+```bash
+docker run -it --rm php:7.2-fpm-buster bash
+```


### PR DESCRIPTION
# OVERVIEW

Fixes some pinned package versions

## WHY THE PULL REQUEST

Nightly builds were failing as the base container image has seen updates to its packages.

## HOW TO QA

Run the build locally and confirm that it builds.


## SCREENSHOTS/EXAMPLES

None

## Checklist

- [x ] Your code builds clean without any errors or warnings
- [x ] You are using approved terminology
- [ ] You have added unit tests
